### PR TITLE
Merge in upstream fix

### DIFF
--- a/timezone_field/__init__.py
+++ b/timezone_field/__init__.py
@@ -1,5 +1,5 @@
 from timezone_field.fields import TimeZoneField
 from timezone_field.forms import TimeZoneFormField
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 __all__ = ['TimeZoneField', 'TimeZoneFormField']

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -3,6 +3,7 @@ import pytz
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import six
+from django.utils.encoding import force_text
 
 from timezone_field.utils import is_pytz_instance
 
@@ -135,6 +136,10 @@ class TimeZoneField(models.Field):
                 return (pytz.timezone(value), value)
             except pytz.UnknownTimeZoneError:
                 pass
+        try:
+            return (pytz.timezone(force_text(value)), force_text(value))
+        except pytz.UnknownTimeZoneError:
+            pass
         raise ValidationError("Invalid timezone '%s'" % value)
 
     def contribute_to_class(self, cls, name, virtual_only=False):

--- a/timezone_field/tests/models.py
+++ b/timezone_field/tests/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 
 from timezone_field import TimeZoneField

--- a/timezone_field/tests/tests.py
+++ b/timezone_field/tests/tests.py
@@ -291,6 +291,7 @@ class TimeZoneFieldDeconstructTestCase(TestCase):
 
     test_fields = (
         TimeZoneField(),
+        TimeZoneField(default='UTC'),
         TimeZoneField(max_length=42),
         TimeZoneField(choices=[
             (pytz.timezone('US/Pacific'), 'US/Pacific'),
@@ -317,6 +318,15 @@ class TimeZoneFieldDeconstructTestCase(TestCase):
         for field in self.test_fields:
             # ensuring the following call doesn't throw an error
             MigrationWriter.serialize(field)
+
+    def test_from_db_value(self):
+        """
+        Verify that the field can handle data coming back as bytes from the
+        db.
+        """
+        field = TimeZoneField()
+        value = field.from_db_value(b'UTC', None, None, None)
+        self.assertEqual(pytz.UTC, value)
 
     def test_default_kwargs_not_frozen(self):
         """


### PR DESCRIPTION
@wesokes what does this fork change from the main library?

I was running into some issues and realized that a change from https://github.com/mfogel/django-timezone-field/pull/39/ that's in the main django-timezone-field library fixed my issue. I went ahead and picked that change into here.