### PR TITLE
AMB-1417: Update choices from common to all timezones

### DIFF
--- a/release_notes.rst
+++ b/release_notes.rst
@@ -1,0 +1,6 @@
+Release Notes
+=============
+
+2.0.5
+------
+* Updated TimeZoneField.CHOICES to include pytz.all_timezones

--- a/timezone_field/__init__.py
+++ b/timezone_field/__init__.py
@@ -1,5 +1,5 @@
 from timezone_field.fields import TimeZoneField
 from timezone_field.forms import TimeZoneFormField
 
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 __all__ = ['TimeZoneField', 'TimeZoneFormField']

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -35,7 +35,7 @@ class TimeZoneField(models.Field):
     Valid inputs:
         * any instance of pytz.tzinfo.DstTzInfo or pytz.tzinfo.StaticTzInfo
         * the pytz.UTC singleton
-        * any string that validates against pytz.common_timezones. pytz will
+        * any string that validates against pytz.all_timezones. pytz will
           be used to build a timezone object from the string.
         * None and the empty string both represent 'no timezone'
 

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -56,7 +56,7 @@ class TimeZoneField(models.Field):
 
     # NOTE: these defaults are excluded from migrations. If these are changed,
     #       existing migration files will need to be accomodated.
-    CHOICES = [(pytz.timezone(tz), tz) for tz in pytz.common_timezones]
+    CHOICES = [(pytz.timezone(tz), tz) for tz in pytz.all_timezones]
     MAX_LENGTH = 63
 
     def __init__(self, choices=None, max_length=None, **kwargs):


### PR DESCRIPTION
### [AMB-1417](https://ambitioninc.atlassian.net/browse/AMB-1417)

Updated CHOICES within the TimeZoneField class to account for pytz's all_timezones rather than just common_timezones. 
Will add tests on the Ambition side, but have it working locally!
